### PR TITLE
Add API Teambuilder with Archetype

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,64 +1,46 @@
 from flask import Blueprint, request, jsonify
+from src.api.teambuilder.teambuilder_api import get_team
 
-views = Blueprint('views', __name__)
+views = Blueprint("views", __name__)
 
 
-@views.route('/home')
+@views.route("/home")
 def api_home():
-    return 'Hello, World!'
+    return "Hello, World!"
 
 
-@views.route('/teambuilder')
+@views.route("/teambuilder", methods=["GET"])
 def api_teambuilder():
-    return [
-        {
-            'name': 'Pikachu',
-            'item': 'Light Ball',
-            'ability': 'Static',
-            'nature': 'Timid',
-            'moves': [
-                'Thunderbolt',
-                'Volt Switch',
-                'Grass Knot',
-                'Quick Attack',
-            ],
-        },
-        {
-            'name': 'Charizard',
-            'item': 'Assault Vest',
-            'ability': 'Blaze',
-            'nature': 'Modest',
-            'moves': [
-                'Flamethrower',
-                'Air Slash',
-                'Dragon Pulse',
-                'Focus Blast',
-            ],
-        }
-    ]
+    archetype = request.args.get("archetype")
+    if not archetype:
+        return jsonify({"error": "Teambuilder archetype parameter is missing"}), 400
+
+    return get_team(archetype)
 
 
-@views.route('/usage-rate')
+@views.route("/usage-rate")
 def api_usage_rate():
     return [
         {
-            'name': 'Pikachu',
-            'usage': 0.5,
+            "name": "Pikachu",
+            "usage": 0.5,
         },
         {
-            'name': 'Charizard',
-            'usage': 0.5,
+            "name": "Charizard",
+            "usage": 0.5,
         },
     ]
 
 
-@views.route('/common-movesets', methods=['GET'])
+@views.route("/common-movesets", methods=["GET"])
 def api_common_movesets():
-    pokemon = request.args.get('pokemon')
+    pokemon = request.args.get("pokemon")
 
     if not pokemon:
-        return jsonify({'error': 'Missing "pokemon" parameter'}), 400
-    
-    return jsonify({
-        'pokemon': pokemon,
-    })
+        return jsonify({"error": 'Missing "pokemon" parameter'}), 400
+
+    return jsonify(
+        {
+            "pokemon": pokemon,
+        }
+    )

--- a/backend/src/api/teambuilder/teambuilder_algo.py
+++ b/backend/src/api/teambuilder/teambuilder_algo.py
@@ -1,0 +1,22 @@
+import random
+import json
+import os
+
+
+def compute_team(archetype: str):
+    """
+    Returns a team based on the archetype provided.
+
+    :param archetype: The archetype of the team to get.
+    :return: the team which consists of a list of pokemon.
+    """
+
+    # For now we will return hardcoded teams
+    try:
+        path = os.path.join(
+            "src", "api", "teambuilder", f"teambuilder_{archetype}.json"
+        )
+        with open(path) as file:
+            return random.choice(json.load(file))
+    except FileNotFoundError:
+        return None

--- a/backend/src/api/teambuilder/teambuilder_api.py
+++ b/backend/src/api/teambuilder/teambuilder_api.py
@@ -1,0 +1,27 @@
+from flask import jsonify
+from .teambuilder_algo import compute_team
+
+ARCHETYPES = set(["ho", "bo", "stall", "balance", "weather"])
+
+
+def get_team(archetype: str):
+    """
+    API for getting a team based on the archetype provided.
+
+    :param archetype: The archetype of the team to get.
+    :return: A JSON response containing the team.
+    """
+    archetype = archetype.lower()
+
+    if archetype not in ARCHETYPES:
+        return (
+            jsonify({"error": f"Invalid archetype should be one of: {ARCHETYPES}"}),
+            400,
+        )
+
+    team = compute_team(archetype)
+
+    if not team or len(team) == 0 or len(team) > 6:
+        return jsonify({"error": f"No team found for archetype: {archetype}"}), 404
+
+    return jsonify(team)

--- a/backend/src/api/teambuilder/teambuilder_bo.json
+++ b/backend/src/api/teambuilder/teambuilder_bo.json
@@ -1,0 +1,147 @@
+[
+  [
+    {
+      "name": "",
+      "species": "Ting-Lu",
+      "gender": "",
+      "item": "Leftovers",
+      "ability": "Vessel of Ruin",
+      "evs": { "hp": 248, "atk": 0, "def": 40, "spa": 0, "spd": 216, "spe": 4 },
+      "nature": "Careful",
+      "moves": ["Earthquake", "Ruination", "Stealth Rock", "Whirlwind"]
+    },
+    {
+      "name": "",
+      "species": "Skarmory",
+      "gender": "",
+      "item": "Rocky Helmet",
+      "ability": "Sturdy",
+      "evs": { "hp": 248, "atk": 0, "def": 164, "spa": 0, "spd": 0, "spe": 96 },
+      "nature": "Impish",
+      "moves": ["Body Press", "Spikes", "Iron Defense", "Roost"]
+    },
+    {
+      "name": "",
+      "species": "Gholdengo",
+      "gender": "",
+      "item": "Air Balloon",
+      "ability": "Good as Gold",
+      "evs": {
+        "hp": 248,
+        "atk": 0,
+        "def": 176,
+        "spa": 0,
+        "spd": 12,
+        "spe": 72
+      },
+      "nature": "Bold",
+      "moves": ["Shadow Ball", "Make It Rain", "Nasty Plot", "Recover"]
+    },
+    {
+      "name": "",
+      "species": "Zamazenta",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Dauntless Shield",
+      "evs": {
+        "hp": 104,
+        "atk": 252,
+        "def": 0,
+        "spa": 0,
+        "spd": 0,
+        "spe": 152
+      },
+      "nature": "Jolly",
+      "moves": ["Close Combat", "Crunch", "Stone Edge", "Heavy Slam"]
+    },
+    {
+      "name": "",
+      "species": "Meowscarada",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Protean",
+      "evs": { "hp": 0, "atk": 252, "def": 0, "spa": 0, "spd": 4, "spe": 252 },
+      "nature": "Jolly",
+      "moves": ["Knock Off", "Flower Trick", "U-turn", "Triple Axel"]
+    },
+    {
+      "name": "",
+      "species": "Toxapex",
+      "gender": "",
+      "item": "Regenerator",
+      "ability": "Protosynthesis",
+      "evs": { "hp": 248, "atk": 0, "def": 0, "spa": 0, "spd": 240, "spe": 20 },
+      "nature": "Calm",
+      "moves": ["Surf", "Toxic", "Haze", "Recover"]
+    }
+  ],
+  [
+    {
+      "name": "",
+      "species": "Kyurem",
+      "gender": "",
+      "item": "Choice Specs",
+      "ability": "Pressure",
+      "evs": { "hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252 },
+      "nature": "Timid",
+      "moves": ["Ice Beam", "Freeze-Dry", "Draco Meteor", "Earth Power"]
+    },
+    {
+      "name": "",
+      "species": "Slowking-Galar",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Regenerator",
+      "evs": { "hp": 252, "atk": 0, "def": 4, "spa": 0, "spd": 252, "spe": 0 },
+      "nature": "Sassy",
+      "moves": ["Future Sight", "Chilly Reception", "Sludge Bomb", "Slack Off"]
+    },
+    {
+      "name": "",
+      "species": "Gliscor",
+      "gender": "",
+      "item": "Toxic Orb",
+      "ability": "Poison Heal",
+      "evs": {
+        "hp": 244,
+        "atk": 0,
+        "def": 56,
+        "spa": 0,
+        "spd": 192,
+        "spe": 16
+      },
+      "nature": "Impish",
+      "moves": ["Earthquake", "Knock Off", "Protect", "Toxic"]
+    },
+    {
+      "name": "",
+      "species": "Skarmory",
+      "gender": "",
+      "item": "Rocky Helmet",
+      "ability": "Sturdy",
+      "evs": { "hp": 252, "atk": 0, "def": 160, "spa": 0, "spd": 0, "spe": 96 },
+      "nature": "Bold",
+      "moves": ["Body Press", "Iron Defense", "Roost", "Stealth Rock"]
+    },
+    {
+      "name": "",
+      "species": "Dragapult",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Infiltrator",
+      "evs": { "hp": 0, "atk": 252, "def": 0, "spa": 0, "spd": 4, "spe": 252 },
+      "nature": "Hasty",
+      "moves": ["Thunder Wave", "Will-O-Wisp", "Hex", "Dragon Darts"]
+    },
+    {
+      "name": "",
+      "species": "Kingambit",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Supreme Overlord",
+      "evs": { "hp": 208, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 48 },
+      "nature": "Adamant",
+      "moves": ["Swords Dance", "Kowtow Cleave", "Sucker Punch", "Iron Head"]
+    }
+  ]
+]

--- a/backend/src/api/teambuilder/teambuilder_ho.json
+++ b/backend/src/api/teambuilder/teambuilder_ho.json
@@ -1,0 +1,128 @@
+[
+  [
+    {
+      "name": "",
+      "species": "Volcarona",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Flame Body",
+      "evs": { "hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252 },
+      "nature": "Timid",
+      "ivs": { "hp": 31, "atk": 0, "def": 31, "spa": 31, "spd": 31, "spe": 31 },
+      "moves": ["Quiver Dance", "Bug Buzz", "Flamethrower", "Tera Blast"]
+    },
+    {
+      "name": "",
+      "species": "Hatterene",
+      "gender": "",
+      "item": "Leftovers",
+      "ability": "Magic Bounce",
+      "evs": { "hp": 252, "atk": 0, "def": 200, "spa": 0, "spd": 0, "spe": 56 },
+      "nature": "Bold",
+      "moves": ["Calm Mind", "Draining Kiss", "Psyshock", "Mystical Fire"]
+    },
+    {
+      "name": "",
+      "species": "Roaring Moon",
+      "gender": "",
+      "item": "Booster Energy",
+      "ability": "Protosynthesis",
+      "evs": { "hp": 0, "atk": 252, "def": 0, "spa": 0, "spd": 4, "spe": 252 },
+      "nature": "Jolly",
+      "moves": ["Dragon Dance", "Knock Off", "Acrobatics", "Earthquake"]
+    },
+    {
+      "name": "",
+      "species": "Glimmora",
+      "gender": "",
+      "item": "Focus Sash",
+      "ability": "Toxic Debris",
+      "evs": { "hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252 },
+      "nature": "Timid",
+      "moves": ["Stealth Rock", "Mortal Spin", "Earth Power", "Power Gem"]
+    },
+    {
+      "name": "",
+      "species": "Kingambit",
+      "gender": "",
+      "item": "Leftovers",
+      "ability": "Supreme Overlord",
+      "evs": { "hp": 208, "atk": 252, "def": 0, "spa": 0, "spd": 4, "spe": 48 },
+      "nature": "Adamant",
+      "moves": ["Swords Dance", "Low Kick", "Sucker Punch", "Iron Head"]
+    },
+    {
+      "name": "",
+      "species": "Iron Boulder",
+      "gender": "",
+      "item": "Booster Energy",
+      "ability": "Quark Drive",
+      "evs": { "hp": 0, "atk": 252, "def": 0, "spa": 0, "spd": 4, "spe": 252 },
+      "nature": "Jolly",
+      "moves": ["Zen Headbutt", "Close Combat", "Mighty Cleave", "Swords Dance"]
+    }
+  ],
+  [
+    {
+      "name": "",
+      "species": "Volcarona",
+      "gender": "",
+      "item": "Heavy-Duty Boots",
+      "ability": "Flame Body",
+      "evs": { "hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252 },
+      "nature": "Modest",
+      "ivs": { "hp": 31, "atk": 0, "def": 31, "spa": 31, "spd": 31, "spe": 31 },
+      "moves": ["Quiver Dance", "Fiery Dance", "Giga Drain", "Tera Blast"]
+    },
+    {
+      "name": "",
+      "species": "Kingambit",
+      "gender": "",
+      "item": "Air Balloon",
+      "ability": "Supreme Overlord",
+      "evs": { "hp": 0, "atk": 252, "def": 4, "spa": 0, "spd": 0, "spe": 252 },
+      "nature": "Jolly",
+      "moves": ["Swords Dance", "Low Kick", "Sucker Punch", "Iron Head"]
+    },
+    {
+      "name": "",
+      "species": "Ogerpon-Wellspring",
+      "gender": "",
+      "item": "Wellspring Mask",
+      "ability": "Water Absorb",
+      "evs": { "hp": 0, "atk": 252, "def": 0, "spa": 0, "spd": 4, "spe": 252 },
+      "nature": "Jolly",
+      "moves": ["Ivy Cudgel", "Trailblaze", "Low Kick", "Swords Dance"]
+    },
+    {
+      "name": "",
+      "species": "Landorus-Therian",
+      "gender": "",
+      "item": "Rocky Helmet",
+      "ability": "Intimidate",
+      "evs": { "hp": 240, "atk": 0, "def": 44, "spa": 0, "spd": 0, "spe": 224 },
+      "nature": "Timid",
+      "moves": ["Stealth Rock", "Taunt", "Earth Power", "U-turn"]
+    },
+    {
+      "name": "",
+      "species": "Primarina",
+      "gender": "",
+      "item": "Custap Berry",
+      "ability": "Torrent",
+      "evs": { "hp": 76, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 176 },
+      "nature": "Modest",
+      "moves": ["Calm Mind", "Moonblast", "Hydro Pump", "Substitute"]
+    },
+    {
+      "name": "",
+      "species": "Dragapult",
+      "gender": "",
+      "item": "Focus Sash",
+      "ability": "Infiltrator",
+      "evs": { "hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252 },
+      "nature": "Hasty",
+      "moves": ["Dragon Darts", "Hex", "Will-O-Wisp", "Thunder Wave"]
+    }
+  ]
+]


### PR DESCRIPTION
close #42

- Added Archetype support for Teambuilder
- Not all archetype  (only HO and BO) are included for testing edge cases and error handling