### PR TITLE
Add API Usage Rate

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify
 from src.api.teambuilder.teambuilder_api import get_team
 from src.data.constants import DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
-from src.data.query_json import get_top_usage
+from src.data.query_json import get_top_usage, get_timeline_usage
 
 
 views = Blueprint("views", __name__)
@@ -45,6 +45,44 @@ def api_usage_rate():
         return jsonify(top_usage)
     except FileNotFoundError:
         return jsonify({"error": f"No usage found for {date}, {tier}, {baseline}"}), 404
+
+
+@views.route("/usage-timeline", methods=["GET"])
+def api_usage_timeline():
+    """
+    API endpoint to get the usage rates for a given set of Pokemon over a specified duration starting from a given date
+    Example usage:
+    /usage-timeline?
+    pokemons=GreatTusk&
+    pokemons=Kingambit&
+    start_date=2023-01&
+    duration=6
+    """
+    pokemons = request.args.getlist("pokemons")
+    start_date = request.args.get("start_date")
+    duration = request.args.get("duration", 1)
+    tier = request.args.get("tier", DEFAULT_TIER)
+    baseline = request.args.get("baseline", DEFAULT_BASELINE)
+
+    if not pokemons:
+        return jsonify({"error": 'Missing "pokemons" parameter'}), 400
+    if not start_date:
+        return jsonify({"error": 'Missing "start_date" parameter'}), 400
+
+    try:
+        usage = get_timeline_usage(
+            pokemons,
+            start_date,
+            int(duration),
+            tier,
+            int(baseline),
+        )
+        return jsonify(usage)
+    except FileNotFoundError:
+        return (
+            jsonify({"error": f"No usage found for {start_date}, {duration}, {tier}"}),
+            404,
+        )
 
 
 @views.route("/common-movesets", methods=["GET"])

--- a/backend/src/data/constants.py
+++ b/backend/src/data/constants.py
@@ -1,7 +1,3 @@
-import os
-
-DATA_DIR = os.path.join("src", "data")
-
 DEFAULT_DATE = "2024-01"
 DEFAULT_TIER = "gen9ou"
 DEFAULT_BASELINE = 1500

--- a/backend/src/data/query_json.py
+++ b/backend/src/data/query_json.py
@@ -1,7 +1,8 @@
 import json
 import os
 from collections import defaultdict
-from src.data.constants import DATA_DIR, DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
+from src.data.constants import DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
+from src.data.usage_parser import get_usage
 
 
 def get_top_usage(
@@ -17,11 +18,8 @@ def get_top_usage(
     :param tier: The tier of the usage data
     :param baseline: The baseline of the usage data
     """
-    data_category = "usage"
-    path = os.path.join(DATA_DIR, data_category, f"{date}_{tier}-{baseline}.json")
-    with open(path) as file:
-        usage = json.load(file)
-        top_usage = usage[:top_n]
+    usage = get_usage(date, tier, baseline)
+    top_usage = usage[:top_n]
 
     return top_usage
 
@@ -46,12 +44,7 @@ def get_timeline_usage(
 
     for _ in range(duration):
         current_date = start_date
-        path = os.path.join(
-            DATA_DIR, data_category, f"{current_date}_{tier}-{baseline}.json"
-        )
-
-        with open(path) as file:
-            usage = json.load(file)
+        usage = get_usage(current_date, tier, baseline)
 
         usage_pokemon = [entry for entry in usage if entry["name"] in pokemons]
         for entry in usage_pokemon:


### PR DESCRIPTION
## Add API Endpoints for Usage Rate
closes #61 

### Overview
Added endpoints `/usage-rate` and `/usage-timeline`:

### Example usage
```
/usage-rate?
	  n=10&
	  date=2023-01&
	  tier=gen9ou&
	  baseline=1500
```
```
/usage-timeline?
	pokemons=GreatTusk&
	pokemons=Kingambit&
	start_date=2023-01&
	duration=6
```