### PR TITLE
Fix pip requests missing

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.1
 Flask-Cors==4.0.0
 pytest==8.0.0
+requests==2.31.0


### PR DESCRIPTION
closes #63 
- Added `requests==2.31.0` requirements.txt