### PR TITLE
Refactor API Usage Rate

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -1,0 +1,12 @@
+const API_BASE_URL = 'https://tobethebest.vercel.app/api';
+const API_TEST_URL = `${API_BASE_URL}/test`;
+
+// API endpoints
+export const API_ENDPOINTS = {
+  TEAMBUILDER: `${API_BASE_URL}/teambuilder`,
+  USAGE_RATE: `${API_BASE_URL}/usage-rate`,
+  USAGE_TOP: `${API_BASE_URL}/usage-top`,
+  USAGE_TIMELINE: `${API_BASE_URL}/usage-timeline`,
+  
+  TEAMBUILDER_TEST: `${API_TEST_URL}/teambuilder`,
+};

--- a/backend/src/api/endpoints.py
+++ b/backend/src/api/endpoints.py
@@ -1,0 +1,118 @@
+from typing import Optional
+from collections import defaultdict
+from src.constants import DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
+from src.data.query_smogon import get_usage
+
+
+def get_usage_rate(
+    pokemon: str,
+    date: str = DEFAULT_DATE,
+    tier: str = DEFAULT_TIER,
+    baseline: int = DEFAULT_BASELINE,
+) -> Optional[dict]:
+    """
+    Get the usage rate for a given Pokemon
+    :param pokemon: The name of the Pokemon
+    :param date: The date of the usage data
+    :param tier: The tier of the usage data
+    :param baseline: The baseline of the usage data
+    :return: The usage rate for the given Pokemon, or None if the Pokemon usage data is not found
+
+    Return format:
+    {
+        "usage_rate": float,
+        "raw_count": int,
+        "real_count": int,
+    }
+    """
+    usage = get_usage(date, tier, baseline)
+    return usage[pokemon]
+
+
+def get_usage_top(
+    top_n: int,
+    date: str = DEFAULT_DATE,
+    tier: str = DEFAULT_TIER,
+    baseline: int = DEFAULT_BASELINE,
+) -> Optional[list]:
+    """
+    Get the top n Pokemon usage rates for a given date, tier, and baseline
+    :param top_n: The top number of Pokemon to return
+    :param date: The date of the usage data
+    :param tier: The tier of the usage data
+    :param baseline: The baseline of the usage data
+    :return: The top n Pokemon usage rates
+
+    Return format:
+    [
+        {
+            "name": str,
+            "usage_rate": float,
+            "raw_count": int,
+            "real_count": int,
+        },
+        ...
+    ]
+    """
+    usage = get_usage(date, tier, baseline)
+    # Merge the name key with the usage data using dictionary unpacking and convert to list
+    usage_list = [{"name": k, **v} for k, v in usage.items()]
+    top_usage = sorted(usage_list, key=lambda x: x["usage_rate"], reverse=True)[:top_n]
+    return top_usage
+
+
+def get_usage_timeline(
+    pokemons: list[str],
+    start_date: str,
+    duration: int = 1,
+    tier: str = DEFAULT_TIER,
+    baseline: int = DEFAULT_BASELINE,
+) -> Optional[dict]:
+    """
+    Get the usage rates for a given set of Pokemon over a specified duration starting from a given date
+    :param pokemons: The set of Pokemon to get usage rates for
+    :param start_date: The start date of the usage data in the format "year-month"
+    :param duration: The number of months to get usage data for
+    :param tier: The tier of the usage data
+    :param baseline: The baseline of the usage data
+    :return: The usage rates for the given set of Pokemon over the specified duration
+
+    Return format:
+    {
+        "pokemon1": [
+            {
+                "usage_rate": float,
+                "raw_count": int,
+                "real_count": int,
+            },
+            ...
+        ],
+        "pokemon2": [
+            {
+                "usage_rate": float,
+                "raw_count": int,
+                "real_count": int,
+            },
+            ...
+        ],
+        ...
+    }
+    """
+    usage_data = defaultdict(list)
+    for _ in range(duration):
+        current_date = start_date
+        usage = get_usage(current_date, tier, baseline)
+
+        for pokemon in pokemons:
+            if usage[pokemon] is not None:
+                usage_data[pokemon].append(usage[pokemon])
+
+        # Increment the date for the next iteration
+        year, month = map(int, current_date.split("-"))
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+        start_date = f"{year}-{month:02d}"
+
+    return usage_data

--- a/backend/src/app/dashboard/usage-rate/page.tsx
+++ b/backend/src/app/dashboard/usage-rate/page.tsx
@@ -2,18 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { Container } from "@mantine/core";
-import {
-  UsageRateChart,
-  UsageRateData,
-} from "@/components/Chart/UsageRateChart";
+import { UsageTopChart, UsageTopData } from "@/components/Chart/UsageTopChart";
 import { API_ENDPOINTS } from "@/api";
 
 export default function UsageRate() {
-  const [usageRateData, setUsageRateData] = useState<UsageRateData[]>([]);
+  const [usageTopData, setUsageTopData] = useState<UsageTopData[]>([]);
   const n = 10;
 
   useEffect(() => {
-    const fetchUsageRateData = async () => {
+    const fetchUsageTopData = async () => {
       try {
         const response = await fetch(`${API_ENDPOINTS.USAGE_TOP}?n=${n}`);
         const data = await response.json();
@@ -23,19 +20,19 @@ export default function UsageRate() {
           Unused: d.raw_count - d.real_count,
         }));
         console.log("usage", usage);
-        setUsageRateData(usage);
+        setUsageTopData(usage);
       } catch (error) {
-        console.error("Error fetching usage rate data:", error);
+        console.error("Error fetching usage top data:", error);
       }
     };
-    fetchUsageRateData();
+    fetchUsageTopData();
   }, [n]);
 
   return (
     <Container size="lg">
       <h1>Usage Rate</h1>
       <h2>Top 10 Most Used Pokemon in January 2024</h2>
-      <UsageRateChart data={usageRateData} />
+      <UsageTopChart data={usageTopData} />
     </Container>
   );
 }

--- a/backend/src/app/dashboard/usage-rate/page.tsx
+++ b/backend/src/app/dashboard/usage-rate/page.tsx
@@ -6,6 +6,7 @@ import {
   UsageRateChart,
   UsageRateData,
 } from "@/components/Chart/UsageRateChart";
+import { API_ENDPOINTS } from "@/api";
 
 export default function UsageRate() {
   const [usageRateData, setUsageRateData] = useState<UsageRateData[]>([]);
@@ -14,9 +15,7 @@ export default function UsageRate() {
   useEffect(() => {
     const fetchUsageRateData = async () => {
       try {
-        const response = await fetch(
-          `https://tobethebest.vercel.app/api/usage-rate?n=${n}`
-        );
+        const response = await fetch(`${API_ENDPOINTS.USAGE_TOP}?n=${n}`);
         const data = await response.json();
         const usage = data.map((d: any) => ({
           pokemon: d.name,

--- a/backend/src/components/Chart/UsageTopChart.tsx
+++ b/backend/src/components/Chart/UsageTopChart.tsx
@@ -1,23 +1,22 @@
 import { BarChart } from "@mantine/charts";
 
-export interface UsageRateData {
+export interface UsageTopData {
   pokemon: string;
   InBattle: number;
   Unused: number;
 }
 
-interface UsageRateChartProps {
-  data: UsageRateData[];
+interface UsageTopChartProps {
+  data: UsageTopData[];
 }
 
-export function UsageRateChart({ data }: UsageRateChartProps) {
+export function UsageTopChart({ data }: UsageTopChartProps) {
   return (
     <BarChart
       h={300}
       data={data}
       dataKey="pokemon"
       type="stacked"
-      withTooltip={false}
       orientation="vertical"
       yAxisProps={{ width: 80 }}
       series={[

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -1,4 +1,5 @@
 SMOGON_STATS = "https://www.smogon.com/stats/"
+
 DEFAULT_DATE = "2024-01"
 DEFAULT_TIER = "gen9ou"
 DEFAULT_BASELINE = 1500

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -1,3 +1,4 @@
+SMOGON_STATS = "https://www.smogon.com/stats/"
 DEFAULT_DATE = "2024-01"
 DEFAULT_TIER = "gen9ou"
 DEFAULT_BASELINE = 1500

--- a/backend/src/data/query_json.py
+++ b/backend/src/data/query_json.py
@@ -1,7 +1,7 @@
 import json
 import os
 from collections import defaultdict
-from src.data.constants import DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
+from src.constants import DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
 from src.data.usage_parser import get_usage
 
 

--- a/backend/src/data/query_smogon.py
+++ b/backend/src/data/query_smogon.py
@@ -1,0 +1,60 @@
+import requests
+from collections import defaultdict
+from src.constants import SMOGON_STATS, DEFAULT_DATE, DEFAULT_TIER, DEFAULT_BASELINE
+
+cache_usage = {}
+
+
+def get_usage(date=DEFAULT_DATE, tier=DEFAULT_TIER, baseline=DEFAULT_BASELINE):
+    """
+    Get the usage data for a given date, tier, and baseline
+    See: https://www.smogon.com/forums/threads/gen-9-smogon-university-usage-statistics-discussion-thread.3711767/
+    :param date: The date of the usage data
+    :param tier: The tier of the usage data
+    :param baseline: The baseline of the usage data
+    :return: The usage data for the given date, tier, and baseline
+
+    Return format:
+    {
+        pokemon: {
+            "usage_rate": float,
+            "raw_count": int,
+            "real_count": int,
+        },
+        ...
+    }
+    """
+    if (date, tier, baseline) in cache_usage:
+        print("query_smogon: cache hit for", (date, tier, baseline), flush=True)
+        return cache_usage[(date, tier, baseline)]
+
+    usage_data = defaultdict(None)
+    url = f"{SMOGON_STATS}{date}/{tier}-{baseline}.txt"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.text
+
+        # Skipping the header and footer
+        lines = data.split("\n")
+        start_index = 5
+        end_index = len(lines) - 2
+
+        for line in lines[start_index:end_index]:
+            elements = line.replace(" ", "").split("|")[1:-1]
+            name = elements[1]
+            usage_rate = elements[2]
+            raw_count = elements[3]
+            real_count = elements[5]
+
+            usage_data[name] = {
+                "usage_rate": float(usage_rate.replace("%", "")),
+                "raw_count": int(raw_count),
+                "real_count": int(real_count),
+            }
+
+        cache_usage[(date, tier, baseline)] = usage_data
+        return usage_data
+    except requests.RequestException as e:
+        print(f"query_smogon: error getting usage data: {e}", flush=True)
+        return usage_data


### PR DESCRIPTION
closes #65 
- Change `/usage-rate` to `/usage-top` since it return top n Pokemon usage rates
- Added `endpoints.py` as an interface for all API endpoints in the backend
- Added `api.ts` with constants for all the API URL